### PR TITLE
Added possibility to configure I2C address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,12 +22,14 @@ const IOEXP_ADDR_LOW: u8 = 0x20;
 const IOEXP_ADDR_HIGH: u8 = 0x21;
 const LARGEST_REG_SIZE_BYTES: usize = 2;
 
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub enum AddrPinState {
     High,
     Low,
 }
 
 impl AddrPinState {
+    #[must_use]
     pub fn address(&self) -> u8 {
         match self {
             Self::High => IOEXP_ADDR_HIGH,


### PR DESCRIPTION
### Configurable I2C address

This is my proposed solution to the problem described in this issue #15 

It enables consumers to use this crate whenever there are two PCAL6416A on the same I2C bus (or if you have one and it has its ADDR pin pulled high).
