### PR TITLE
docs: add AGENTS.md and model-selection guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,8 @@
+> **Read `AGENTS.md` first.** This file is kept minimal on purpose;
+> `AGENTS.md` (at the repo root) is the canonical source of project
+> conventions, build commands, and agent guidance for any AI coding
+> assistant working on this repository.
+
 # Copilot Instructions
 
 ## Commit Messages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,323 @@
+# AGENTS.md — `pcal6416a`
+
+Canonical guidance for AI coding assistants (and humans) working on this
+repository. This file is the source of truth for project conventions,
+build/test commands, and code-style rules. `.github/copilot-instructions.md`
+intentionally defers to this file.
+
+## What this crate is
+
+`pcal6416a` is a platform-agnostic, `#![no_std]` Rust driver for the NXP
+[PCAL6416A](https://www.nxp.com/docs/en/data-sheet/PCAL6416A.pdf) 16-bit I²C
+I/O expander. It is built on top of the [`embedded-hal`] and
+[`embedded-hal-async`] 1.0 traits and uses the [`device-driver`] crate to
+generate the register interface from `device.yaml`.
+
+Key facts (see `Cargo.toml`):
+
+- Package: `pcal6416a` `0.3.0`, MIT-licensed, Rust **edition 2024**.
+- Categories: `embedded`, `hardware-support`, `no-std`.
+- Lints in the manifest: `unsafe_code = "forbid"`, `missing_docs = "deny"`,
+  clippy `correctness`/`suspicious`/`perf`/`style = "forbid"`,
+  `pedantic = "deny"`. Do not weaken these.
+- MSRV enforced in CI: **Rust 1.85** (see `.github/workflows/check.yml`
+  `msrv` job). The README still says `1.81`; treat the CI value as
+  authoritative until the README is fixed.
+- Single optional feature: `defmt` (enables `defmt` derives and forwards
+  `device-driver/defmt-03`).
+- Patched dependencies: `embedded-hal` and `embedded-hal-async` are pinned
+  to `git = "https://github.com/rust-embedded/embedded-hal.git"` via
+  `[patch.crates-io]`. Expect `Cargo.lock` churn on `cargo update`.
+
+[`embedded-hal`]: https://docs.rs/embedded-hal
+[`embedded-hal-async`]: https://docs.rs/embedded-hal-async
+[`device-driver`]: https://docs.rs/device-driver
+
+## Repository layout
+
+```
+.
+├── AGENTS.md                       ← you are here
+├── Cargo.toml                      ← crate manifest, lint config, features
+├── README.md                       ← short user-facing intro
+├── CONTRIBUTING.md                 ← licensing/DCO note
+├── CODE_OF_CONDUCT.md
+├── CODEOWNERS
+├── LICENSE                         ← MIT
+├── SECURITY.md
+├── deny.toml                       ← cargo-deny config
+├── rustfmt.toml                    ← nightly-only options (see below)
+├── build.rs                        ← rebuild trigger for device.yaml
+├── device.yaml                     ← register map consumed by device-driver
+└── src/
+    └── lib.rs                      ← entire driver + unit tests (#[cfg(test)])
+└── .github/
+    ├── copilot-instructions.md     ← minimal pointer, see end of this file
+    └── workflows/
+        ├── check.yml               ← fmt, clippy, semver, doc, hack, deny, msrv
+        └── nostd.yml               ← cargo check on thumbv8m.main-none-eabihf
+```
+
+There are no `examples/`, `tests/`, or `benches/` directories. All tests live
+in the `#[cfg(test)] mod tests` block at the bottom of `src/lib.rs`.
+
+## Building and testing
+
+All commands below have been verified against `main` on Windows with a
+standard `rustup` install. They match what CI runs in
+`.github/workflows/check.yml` and `nostd.yml`.
+
+### Default build
+
+```sh
+cargo build
+```
+
+### Unit tests
+
+The unit tests use `embedded-hal-mock` and `tokio` (for `#[tokio::test]`
+async tests):
+
+```sh
+cargo test
+```
+
+There are currently 59 unit tests + 1 ignored doctest. All run on the host
+(they do not require hardware).
+
+### Formatting
+
+```sh
+cargo fmt --check
+```
+
+`rustfmt.toml` sets `group_imports = "StdExternalCrate"` and
+`imports_granularity = "Module"`, which are nightly-only options. On stable
+`cargo fmt --check` prints warnings like
+`unstable features are only available in nightly channel` but still exits 0.
+CI runs `cargo fmt --check` on the **nightly** toolchain (see the `fmt`
+job), so before submitting you should match that:
+
+```sh
+cargo +nightly fmt --check
+```
+
+### Clippy
+
+CI matches `dtolnay/rust-toolchain@master` for `stable` and `beta` and runs
+clippy via `giraffate/clippy-action@v1` with the explicit flags below. To
+reproduce locally:
+
+```sh
+cargo clippy -- -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
+```
+
+Note that `Cargo.toml` already promotes those four groups to `forbid` and
+`pedantic` to `deny`, so a plain `cargo clippy` will also fail on the same
+issues; the explicit `-F` flags above mirror CI exactly.
+
+### Documentation
+
+```sh
+RUSTDOCFLAGS="--cfg docsrs" cargo doc --no-deps --all-features
+```
+
+PowerShell equivalent:
+
+```powershell
+$env:RUSTDOCFLAGS = "--cfg docsrs"
+cargo doc --no-deps --all-features
+```
+
+### Feature-powerset check (cargo-hack)
+
+```sh
+cargo install cargo-hack    # one-time
+cargo hack --feature-powerset check
+```
+
+This iterates over `{}` and `{defmt}` (the only feature).
+
+### MSRV check
+
+```sh
+rustup toolchain install 1.85
+cargo +1.85 check
+```
+
+### `no_std` target check
+
+```sh
+rustup target add thumbv8m.main-none-eabihf
+cargo check --target thumbv8m.main-none-eabihf --no-default-features
+```
+
+### Supply-chain checks (cargo-deny, cargo-semver-checks)
+
+Both run in CI but are not required locally:
+
+```sh
+cargo install cargo-deny
+cargo deny --manifest-path ./Cargo.toml check --all-features
+
+cargo install cargo-semver-checks
+cargo semver-checks
+```
+
+## Code conventions
+
+- **Edition:** Rust 2024. Use 2024-edition idioms (e.g. `let … else`,
+  expression-position `match` cleanups). Do not regress to 2021.
+- **`no_std`:** The crate is `#![cfg_attr(not(test), no_std)]`. Anything in
+  the non-test path must not use `std`. Tests may use `std` (and do — they
+  use `tokio` and `Vec`).
+- **Unsafe:** `unsafe_code = "forbid"` at the crate level. Do not introduce
+  `unsafe` blocks; if you genuinely need one, that is an architectural
+  discussion, not a local change.
+- **Missing docs:** `missing_docs = "deny"`. The crate-level
+  `#![allow(missing_docs)]` opt-out exists only because the generated
+  `device-driver` items would otherwise trip it. New hand-written public
+  items should still carry doc comments.
+- **Clippy:** Treat `pedantic` as a hard requirement (it is `deny`). Use
+  `#[must_use]` on pure accessors (`AddrPinState::address`, `Pin::bit`,
+  `Pin::number`, etc.), prefer `const fn` where possible, and avoid the
+  patterns clippy-pedantic flags (unnecessary clones, needless borrows,
+  shadowed names, etc.).
+- **Formatting:** `max_width = 120`, `imports_granularity = "Module"`,
+  `group_imports = "StdExternalCrate"`. Use `cargo +nightly fmt` before
+  pushing so the import grouping actually takes effect.
+- **Error type:** A single generic `Pcal6416aError<E>` wraps the I²C error
+  type and implements `embedded_hal::digital::Error`. New fallible APIs
+  should return `Result<_, Pcal6416aError<I2c::Error>>`, not bespoke error
+  types.
+- **Sync vs async:** The crate provides both
+  `device_driver::RegisterInterface` (blocking, `embedded_hal::i2c::I2c`)
+  and `device_driver::AsyncRegisterInterface` (async,
+  `embedded_hal_async::i2c::I2c`) impls for `Pcal6416aDevice<I2c>`. When
+  adding a new operation, provide both flavours and add tests for each
+  (look for the `_async` suffix convention on test functions).
+
+## Driver / HAL specifics
+
+- **Register map:** `device.yaml` is the single source of truth for the
+  PCAL6416A register layout. The `device_driver::create_device!` macro in
+  `src/lib.rs` generates the `Device` type and per-register accessors from
+  it. Prefer editing `device.yaml` over hand-rolling register code.
+  `build.rs` emits `cargo:rebuild-if-changed=device.yaml` so edits trigger
+  a rebuild.
+- **YAML conventions:** `default_byte_order: LE`, `default_bit_order: LSB0`,
+  `defmt_feature: defmt`. Per-pin fields are named `<reg-prefix>_<port>_<bit>`
+  (e.g. `I0_3`, `O1_7`, `PE0_0`, `PUD1_5`). Keep that pattern when adding
+  fields so the generated accessor names stay consistent (`i_0_3()`, etc.).
+- **I²C address:** `IOEXP_ADDR_LOW = 0x20` and `IOEXP_ADDR_HIGH = 0x21`,
+  selected by the `AddrPinState` (`Low`/`High`) field on `Pcal6416aDevice`.
+- **Register width:** `LARGEST_REG_SIZE_BYTES = 2`. Both `write_register`
+  impls allocate a `[u8; 1 + LARGEST_REG_SIZE_BYTES]` stack buffer and
+  write `&buf[..=data.len()]` so 1-byte writes don't accidentally clobber
+  the next register. Preserve this if you change the I²C transaction code.
+- **Shared device / pin splitting:** `SharedDevice<I2c, M>` wraps a
+  `Device` inside `embassy_sync::mutex::Mutex<M, _>` and exposes per-pin
+  `IoPin<'a, I2c, M>` handles via `split()`. The `RawMutex` parameter `M`
+  is supplied by the caller (e.g. `CriticalSectionRawMutex`,
+  `NoopRawMutex`). `IoPin` implements the
+  `embedded-hal-async` digital traits.
+- **`defmt`:** Public error/enum types use
+  `#[cfg_attr(feature = "defmt", derive(defmt::Format))]`. Mirror that
+  pattern on any new public enum or error.
+
+## Commit & PR conventions
+
+Verified against `git log --pretty=%s` on `main`:
+
+- Subject line: imperative mood, capitalised, ≤ 50 characters where
+  practical. The repo accepts both Conventional-Commits style
+  (`feat: add GPIO pin interface…`) and plain imperative subjects
+  (`More registers in device.yaml`, `Added blocking implementation`).
+  When in doubt, prefer Conventional Commits.
+- Blank line between subject and body; wrap body at 72 columns; the body
+  should explain **what** and **why**, not how.
+- PR titles are typically suffixed with the PR number by GitHub's
+  squash-merge (e.g. `… (#21)`). You do not need to add this yourself.
+- **AI attribution (required):** every commit that includes AI-generated
+  or AI-assisted work must carry an `Assisted-by` trailer:
+
+  ```
+  Assisted-by: <AGENT_NAME>:<MODEL_VERSION> [TOOL1] [TOOL2]
+  ```
+
+  Example:
+
+  ```
+  Assisted-by: GitHub Copilot:claude-opus-4.7
+  ```
+
+  AI agents must verify their own identity (agent name and model version)
+  before composing this trailer — do not hard-code a value from a previous
+  session.
+- **No `Signed-off-by` from AI agents.** Only humans may certify the DCO.
+- See `.github/copilot-instructions.md` for the canonical AI-attribution
+  wording.
+
+## What not to do
+
+- Don't introduce `unsafe` (lint is `forbid`).
+- Don't downgrade or `allow(...)`-away the clippy `forbid`/`deny` lints in
+  `Cargo.toml` to make code compile. Fix the underlying issue.
+- Don't add a `std` dependency to the non-test compilation path.
+- Don't hand-edit register accessor code that ought to come from
+  `device.yaml` via `device_driver::create_device!`.
+- Don't change the I²C wire format in
+  `Pcal6416aDevice::{read,write}_register` without preserving the
+  "write only `&buf[..=data.len()]` bytes" behaviour described above.
+- Don't force-push to shared branches and don't open PRs from an AI
+  agent without a human reviewer.
+
+## How to find more context
+
+- **Datasheet:** <https://www.nxp.com/docs/en/data-sheet/PCAL6416A.pdf>
+- **`device-driver` crate docs:** <https://docs.rs/device-driver>
+- **`embedded-hal` 1.0:** <https://docs.rs/embedded-hal/1.0.0>
+- **`embedded-hal-async` 1.0:** <https://docs.rs/embedded-hal-async/1.0.0>
+- **`embassy-sync`:** <https://docs.rs/embassy-sync>
+- **CI definitions:** `.github/workflows/check.yml`,
+  `.github/workflows/nostd.yml` — always the source of truth for what
+  "green" means.
+
+---
+
+## Incorporated from `.github/copilot-instructions.md`
+
+The following is the full content of `.github/copilot-instructions.md` at
+the time of writing, kept here so this file is a strict superset:
+
+### Commit Messages
+- Subject line: capitalized, 50 characters or less, imperative mood
+  (e.g., "Fix bug" not "Fixed bug")
+- Separate subject from body with a blank line
+- Wrap body text at 72 characters
+- Use the body to explain *what* and *why*, not *how*
+
+### AI Attribution
+Every commit that includes AI-generated or AI-assisted work **must**
+contain an `Assisted-by` trailer in the commit message:
+
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+```
+
+Where:
+- `AGENT_NAME` is the name of the AI tool or framework
+  (e.g., `GitHub Copilot`)
+- `MODEL_VERSION` is the specific model version used
+  (e.g., `claude-opus-4.6`)
+- `[TOOL1] [TOOL2]` are optional specialized analysis tools used
+  (e.g., `coccinelle`, `sparse`, `smatch`, `clang-tidy`)
+
+Basic development tools (git, cargo, editors) should not be listed.
+
+AI agents **must** verify their own identity (agent name and model
+version) before composing the `Assisted-by` trailer — do not assume or
+hard-code a model name from a previous session.
+
+AI agents **MUST NOT** add `Signed-off-by` tags. Only humans can certify
+the Developer Certificate of Origin.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,3 +321,92 @@ hard-code a model name from a previous session.
 
 AI agents **MUST NOT** add `Signed-off-by` tags. Only humans can certify
 the Developer Certificate of Origin.
+
+## Model selection & cost discipline
+
+Premium models (Opus, GPT-5 family, "high"/"xhigh" reasoning variants)
+cost an order of magnitude more than standard models (Sonnet, Haiku,
+mini). Most steps in a typical task do not need premium reasoning,
+and over-using premium models wastes credits without improving
+outcomes. The rules below apply to *all* model selection: your own
+session, sub-agents launched via the `task` tool, and parallel work
+launched via `/fleet`.
+
+### Default posture
+
+- **Default to the cheapest model that can do the job.** Reach for a
+  premium model only when one of the escalation triggers below is hit.
+- **Plan with premium, execute with cheap.** Spend at most one or two
+  premium turns on design / planning, then downshift to a cheaper
+  model for mechanical execution of the plan.
+- **Never bump the model "just in case."** If you cannot articulate
+  *why* a cheaper model would fail, use the cheaper model.
+
+### Escalation triggers (use a premium model)
+
+Reach for a premium model when *any* of these are true:
+
+- Cross-module refactor, architectural design, or API design from
+  scratch.
+- Subtle correctness reasoning: concurrency, lifetimes, `unsafe`,
+  FFI ABI, cryptography, safety-critical control paths.
+- Debugging a failure that survived one prior cheap-model attempt.
+- Reviewing code on a safety-, security-, or money-critical path.
+- The diff cannot be predicted in advance — i.e. there is genuine
+  creative or design work to do, not just typing.
+
+### De-escalation triggers (use a cheap model)
+
+Use the cheapest available model when *any* of these are true:
+
+- Searching, reading, summarising files or docs.
+- Single-file mechanical edits: rename, format, lint fix, dependency
+  bump, boilerplate, scaffolding from a known template.
+- Generating tests for code that already works.
+- Running builds, tests, linters, or other commands where the model
+  only needs to report success/failure.
+- Routine commits, PR descriptions, changelog entries.
+- The diff is essentially predictable before generation.
+
+### Sub-agent routing (the `task` tool)
+
+When delegating with the `task` tool, set `model:` explicitly. Do not
+let sub-agents inherit a premium default for cheap work.
+
+| Sub-agent type    | Default model             | Override to                                     |
+|-------------------|---------------------------|-------------------------------------------------|
+| `explore`         | cheap                     | keep cheap (`claude-haiku-4.5` or `gpt-5-mini`) |
+| `task` (run cmd)  | cheap                     | keep cheap                                      |
+| `research`        | cheap for breadth         | premium only for the final synthesis            |
+| `general-purpose` | match task                | cheap for mechanical work; premium for design   |
+| `rubber-duck`     | premium                   | keep premium — this is where reasoning pays off |
+| `code-review`     | premium on critical paths | cheap on cosmetic / mechanical diffs            |
+
+### `/fleet` (parallel sub-agents) rules
+
+- Fleet mode multiplies cost by the fleet width. Apply the rules
+  above *per worker*, not in aggregate.
+- Split a fleet job along complexity lines: route the cheap,
+  parallelisable workers (file edits, test runs, doc updates) to a
+  cheap model; reserve premium models for the small number of
+  workers that need real reasoning.
+- If every worker in a fleet would need a premium model, the work is
+  probably not a good fit for fleet mode — reconsider the
+  decomposition before paying N× premium.
+
+### Session hygiene
+
+- Keep sessions short and focused. Long premium sessions are the
+  single largest source of waste because every turn re-processes the
+  full history.
+- Use `/compact` when the conversation grows long, and `/new` for
+  unrelated work.
+- Prefer `/ask` for one-off side questions so they don't extend the
+  main session.
+
+### When in doubt
+
+Ask: *"If a cheaper model produced the wrong answer here, would I
+catch it in seconds (compiler, tests, my own review) or in
+weeks (production incident)?"* If the former, use the cheap model
+and let the feedback loop do its job.


### PR DESCRIPTION
This PR adds an `AGENTS.md` file (see [agents.md](https://agents.md/)) tailored to this repository, distilled from the project's CI workflows, configuration, source layout, and conventions. The goal is to give any AI coding agent (Copilot, Claude, Cursor, etc.) enough repo-specific context to be immediately productive without re-deriving conventions from scratch.

**Commit 1 — `docs: add AGENTS.md ...`**
- New `AGENTS.md` with project overview, build/test/lint/fmt commands, code layout, contribution patterns, and any quirks observed (e.g., `defmt` feature constraints, nightly-only `rustfmt.toml` options, workspace layout).
- `.github/copilot-instructions.md` updated to point at `AGENTS.md` as the authoritative source, so Copilot-specific configuration does not drift out of sync with the broader agent guidance. Where no `copilot-instructions.md` existed, a minimal pointer file was added.

**Commit 2 — `docs(AGENTS.md): add model selection & cost discipline section`**
- Adds a "Model selection & cost discipline" section covering when to use premium vs. cheap models, escalation/de-escalation triggers, sub-agent routing defaults, `/fleet` rules, and session-hygiene tips. The aim is to keep premium reasoning for genuinely hard work and route mechanical edits to cheaper models, reducing wasted spend without sacrificing quality.

No source code, dependencies, or CI behavior is changed by this PR — it is documentation only.

Marked as **draft** for review; happy to iterate on tone, scope, or any repo-specific detail that should be tightened up.

---
Assisted by GitHub Copilot (Claude Opus 4.7).